### PR TITLE
Initial support for signing MSIX and MSIX bundle files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -92,3 +92,4 @@ Session.vim
 tags
 
 .vscode
+relic

--- a/config/config.go
+++ b/config/config.go
@@ -51,8 +51,9 @@ type TokenConfig struct {
 	Retries    int     // (server) Retry failed commands N times (default 5)
 	User       *uint   // User argument for PKCS#11 login (optional)
 	UseKeyring bool    // Read PIN from system keyring
-
-	name string
+	ReadWrite  bool    // Set the connection to read/write mode
+	AutoLogin  bool    // Attempt to authenticate automatically
+	name       string
 }
 
 type KeyConfig struct {

--- a/doc/msix.md
+++ b/doc/msix.md
@@ -1,0 +1,36 @@
+# Signing MSIX packages
+
+## Context
+
+MSIX is a Windows app package format that was introduced in Windows 10. It is an evolution of the previous APPX format, and it is designed to make application installation, distribution, and updating more efficient and secure. MSIX packages are container files that can contain all the necessary resources, dependencies, and metadata needed for an application to run on a Windows system. They use a combination of technologies such as containerization, digital signatures, and runtime APIs to ensure that the apps are secure, reliable, and easy to manage. MSIX packages can be installed through various methods, including the Microsoft Store, Microsoft Endpoint Manager, and standalone installation packages.
+
+## Requirements
+
+You should have a `relic` configuration file, you can find more details by visiting the [relevant documentation](https://github.com/sassoftware/relic/blob/6e27811296dcc5beef771a67d09880f1a1da07e2/doc/relic.yml). 
+
+If you're looking for a minimal proof of concept, create the following in `~/.config/relic:`
+
+```yml
+---
+tokens:
+  file:
+    type: file
+keys:
+  my_file_key:
+    token: file
+    keyfile: /path/to/your/key/rsa2048.key
+    x509certificate: /path/to/your/cert/rsa2048.crt
+```
+
+For PKCS11 backed keys, see documentation. If you don't have sample certificates and keys, for testing purposes you can use the ones in this [repo](functest/testkeys). 
+
+## Signing
+
+To sign a single MSIX package, use the following:
+
+```bash
+./relic sign --file /path/to/package.msix --key my_file_key
+```
+
+Currently, to sign an MSIX bundle, you must first sign each individual MSIX package, use a tool to package the final file, and then sign the final file.
+

--- a/lib/signappx/structs.go
+++ b/lib/signappx/structs.go
@@ -24,13 +24,13 @@ import (
 )
 
 const (
-	appxSignature     = "AppxSignature.p7x"
-	appxCodeIntegrity = "AppxMetadata/CodeIntegrity.cat"
-	appxBlockMap      = "AppxBlockMap.xml"
-	appxManifest      = "AppxManifest.xml"
-	appxContentTypes  = "[Content_Types].xml"
-
+	appxSignature      = "AppxSignature.p7x"
+	appxCodeIntegrity  = "AppxMetadata/CodeIntegrity.cat"
+	appxBlockMap       = "AppxBlockMap.xml"
+	appxManifest       = "AppxManifest.xml"
+	appxContentTypes   = "[Content_Types].xml"
 	bundleManifestFile = "AppxMetadata/AppxBundleManifest.xml"
+	resourcesPri       = "resources.pri"
 )
 
 type AppxSignature struct {

--- a/signers/appx/signer.go
+++ b/signers/appx/signer.go
@@ -61,7 +61,7 @@ func verify(f *os.File, opts signers.VerifyOpts) ([]*signers.Signature, error) {
 	if err != nil {
 		return nil, err
 	}
-	sig, err := signappx.Verify(f, size, opts.NoDigests)
+	sig, err := signappx.Verify(f, size, opts.NoDigests, false)
 	if err != nil {
 		return nil, err
 	}

--- a/token/p11token/token.go
+++ b/token/p11token/token.go
@@ -107,17 +107,22 @@ func Open(config *config.Config, tokenName string, pinProvider passprompt.Passwo
 		tok.Close()
 		return nil, err
 	}
-	mode := uint(pkcs11.CKF_SERIAL_SESSION | pkcs11.CKF_RW_SESSION)
+	mode := uint(pkcs11.CKF_SERIAL_SESSION)
+	if tokenConf.ReadWrite {
+		mode = mode | pkcs11.CKF_RW_SESSION
+	}
 	sh, err := tok.ctx.OpenSession(slot, mode)
 	if err != nil {
 		tok.Close()
 		return nil, err
 	}
 	tok.sh = sh
-	err = tok.autoLogIn(pinProvider)
-	if err != nil {
-		tok.Close()
-		return nil, err
+	if tokenConf.AutoLogin {
+		err = tok.autoLogIn(pinProvider)
+		if err != nil {
+			tok.Close()
+			return nil, err
+		}
 	}
 	return tok, nil
 }


### PR DESCRIPTION
## What 
Introduces initial support for signing MSIX/MSIX Bundle files as an addition over the existing signappx code.

## Why 
Microsoft has not published official guidelines of how MSIX signing actually works, but trial and error shows that for the most part it is compatible with APPX signing, which several tools implement, despite that not being documented either.

## How
- When processing MSIX bundle files, avoid adding .msix packages into the BlockMap and messing the hashes.
- When verifying the signature, do not enforce code integrity and catalog verification on resource packages, which do not and should not contain them.
- Fix the bin patch codepath where the initial patch start was determined prior to adding all the files in the output package, and therefore the central directory of the zip file could end up misplaced; instead, calculate the path start once we know its final position